### PR TITLE
Migrate to github actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,18 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: java
-jdk: openjdk8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/SBI-/minigit/workflows/Java%20CI/badge.svg?branch=master)
+![](https://github.com/SBI-/minigit/workflows/Java%20CI/badge.svg)
 
 # minigit
 Extremely small and light weight java git service library.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/SBI-/minigit.svg?branch=master)](https://travis-ci.org/SBI-/minigit)
-
 # minigit
 Extremely small and light weight java git service library.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/SBI-/minigit/workflows/Java%20CI/badge.svg?branch=master)
+
 # minigit
 Extremely small and light weight java git service library.
 


### PR DESCRIPTION
As github now offers builds with their actions, we can drop travis ci and use github actions instead.